### PR TITLE
Add .gitignore for .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
We don't want pesky .DS_Store files being committed to the repo, so this just tells git to ignore them.