### PR TITLE
Update gitignore with python files and a scratch folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+scratch
 .DS_Store
+__pycache__
+*.py[cod]
+*$py.class


### PR DESCRIPTION
- python files are so that we don't accidentally commit compiled python files
- scratch folder is because i like having a folder called `scratch` that git doesn't touch to do quick testing in