### PR TITLE
Add basic pylintrc config

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,3 @@
+[MASTER]
+
+disable=C0114,C0115,C0116


### PR DESCRIPTION
I like using the pylint in addition to flake/cornflakes, this just a adds config makes pylint a little less insane about requiring docstrings everywhere.