### PR TITLE
Add an abstracted function for loading a dm3 image as a numpy array

### DIFF
--- a/nrcemt/alignment_software/engine/img_loading.py
+++ b/nrcemt/alignment_software/engine/img_loading.py
@@ -1,0 +1,15 @@
+from .dm3 import DM3Image
+
+
+def load_dm3(filename):
+    """
+    Loads just the image data form a DM3 file as a 2D numpy array.
+    Other image metadata included in the DM3 file format is ignored.
+    """
+    with open(filename, 'rb') as file:
+        img = DM3Image.read(file)
+        img_data = img.tag_group["ImageList"][0]["ImageData"]
+        width = img_data["Dimensions"][0].decode()
+        height = img_data["Dimensions"][1].decode()
+        array = img_data["Data"].decode()
+        return array.reshape((width, height))

--- a/nrcemt/alignment_software/test/test_img_loading.py
+++ b/nrcemt/alignment_software/test/test_img_loading.py
@@ -1,0 +1,23 @@
+import os
+import hashlib
+from nrcemt.alignment_software.engine.img_loading import load_dm3
+
+
+dirname = os.path.dirname(__file__)
+filename = os.path.join(dirname, 'resources/image_001.dm3')
+
+
+def test_dm3_reading():
+    img = load_dm3(filename)
+    assert img.shape == (384, 384)
+    img_hash = compute_bytes_sha256(img.tobytes())
+    assert (
+        img_hash ==
+        "57c9d6ad22881e139e9594ce6cffa30a63c3e62b8e13f9729d4f6856e0e85bac"
+    )
+
+
+def compute_bytes_sha256(byte_string):
+    sha256 = hashlib.sha256()
+    sha256.update(byte_string)
+    return sha256.hexdigest()


### PR DESCRIPTION
closes #99
This just uses the already implemented dm3 reader. This just simplifies the interface to make in cleaner for the GUI to make calls to. It takes as input, a filepath and returns a 2d array for the image.