### PR TITLE
Fix dm3 loading thumbnail instead of high resolution

### DIFF
--- a/nrcemt/alignment_software/engine/img_loading.py
+++ b/nrcemt/alignment_software/engine/img_loading.py
@@ -8,7 +8,7 @@ def load_dm3(filename):
     """
     with open(filename, 'rb') as file:
         img = DM3Image.read(file)
-        img_data = img.tag_group["ImageList"][0]["ImageData"]
+        img_data = img.tag_group["ImageList"][1]["ImageData"]
         width = img_data["Dimensions"][0].decode()
         height = img_data["Dimensions"][1].decode()
         array = img_data["Data"].decode()

--- a/nrcemt/alignment_software/test/test_img_loading.py
+++ b/nrcemt/alignment_software/test/test_img_loading.py
@@ -9,11 +9,11 @@ filename = os.path.join(dirname, 'resources/image_001.dm3')
 
 def test_dm3_reading():
     img = load_dm3(filename)
-    assert img.shape == (384, 384)
+    assert img.shape == (1024, 1024)
     img_hash = compute_bytes_sha256(img.tobytes())
     assert (
         img_hash ==
-        "57c9d6ad22881e139e9594ce6cffa30a63c3e62b8e13f9729d4f6856e0e85bac"
+        "ca25e893b60460a8f1b745ac7e4cf9a3f9ab049900fa8f72bc537e06873af2d6"
     )
 
 


### PR DESCRIPTION
I made a mistake in previous DM3 loading code, I was accidentally loading the lower resolution thumbnail instead of the full resolution image, this fixes that and updates the test.