### PR TITLE
Fix img_io import

### DIFF
--- a/nrcemt/alignment_software/test/test_particle_tracking.py
+++ b/nrcemt/alignment_software/test/test_particle_tracking.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-from nrcemt.alignment_software.engine.img_loading import load_dm3
+from nrcemt.alignment_software.engine.img_io import load_dm3
 from nrcemt.alignment_software.engine.img_processing import (
     adjust_img_range, reject_outliers_percentile
 )


### PR DESCRIPTION
when we merged the tests failed because a module was renamed in a previous pr and I forgot to pull the latest changes before making my changes. This caused the import to fail.